### PR TITLE
Reorganize and edit for clarity and concision

### DIFF
--- a/exercise-content.md
+++ b/exercise-content.md
@@ -1,10 +1,5 @@
-## What is the difference between push, pull, and fetch?
-Git fetch, pull, and push are commands that help you understand and synchronize changes between a local and remote repository. 
-
-### Push
-- `git push` - sent changes from a local branch to a remote repo
-
-`git push` takes our current branch, and checks to see whether or not there is a tracking branch for a remote repository connected to it. If so, our changes are taken from our branch and pushed to the remote branch. This is how code is shared with a remote repository, you can think of it as "make the remote branch resemble my local branch". This will fail if the remote branch has diverged from your local branch: if not all the commits in the remote branch are in your local branch. When this happens, your local branch needs to be synchronized with the remote branch with git pull or git fetch and git merge.
+## What is the difference between fetch, pull, and push?
+Git fetch, pull, and push are commands that help you understand and synchronize changes between a local and remote repository.
 
 ### Fetch
 - `git fetch` - get changes from a remote repo into your tracking branch
@@ -15,3 +10,8 @@ Git fetch, pull, and push are commands that help you understand and synchronize 
 - `git pull` - will get changes from a remote branch into your tracking branch and merge them into a local branch
 
 `git pull` simply does a `git fetch` followed immediately by `git merge`. This is often what we desire to do, but some people prefer to use git fetch followed by git merge to make sure they understand the changes they are merging into their branch before the merge happens.
+
+### Push
+- `git push` - sent changes from a local branch to a remote repo
+
+`git push` takes our current branch, and checks to see whether or not there is a tracking branch for a remote repository connected to it. If so, our changes are taken from our branch and pushed to the remote branch. This is how code is shared with a remote repository, you can think of it as "make the remote branch resemble my local branch". This will fail if the remote branch has diverged from your local branch: if not all the commits in the remote branch are in your local branch. When this happens, your local branch needs to be synchronized with the remote branch with git pull or git fetch and git merge.

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -1,5 +1,5 @@
 ## What is the difference between push, pull, and fetch?
-Often `git push` and `git pull` are described as equivalent. This isn't entirely correct, since under the hood `git pull` does two things.
+Git fetch, pull, and push are commands that help you understand and synchronize changes between a local and remote repository. 
 
 ### Push
 - `git push` - sent changes from a local branch to a remote repo

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -10,11 +10,10 @@ When you're ready, use `git merge` to integrate changes into your local working 
 ### Pull
 
 `git pull` combines two actions into the same operation:
-1. Download all of the branches, tags, and changes from a remote repository into your local repository.
+1. Download all of the branches, tags, and changes from a remote repository into your local repository. This is equivalent to performing a `git fetch`.
 
-2. Integrate the changes from a remote tracking branch into your local tracking branch.
+2. Integrate the changes from a remote tracking branch into your local tracking branch. This is equivalent to performing a `git merge`.
 
-This is equivalent to performing a `git fetch` and then a `git merge`. 
 
 ### Push
 - `git push` - sent changes from a local branch to a remote repo

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -16,6 +16,6 @@ When you're ready, use `git merge` to integrate changes into your local working 
 
 
 ### Push
-- `git push` - sent changes from a local branch to a remote repo
+`git push` sends your local commits to the tracking branch in your remote repository.
 
-`git push` takes our current branch, and checks to see whether or not there is a tracking branch for a remote repository connected to it. If so, our changes are taken from our branch and pushed to the remote branch. This is how code is shared with a remote repository, you can think of it as "make the remote branch resemble my local branch". This will fail if the remote branch has diverged from your local branch: if not all the commits in the remote branch are in your local branch. When this happens, your local branch needs to be synchronized with the remote branch with git pull or git fetch and git merge.
+Before you can push, you must update your local branch with the latest commits from the remote branch using either `git pull` or `git fetch` and then `git merge`. After you push, you may want to submit a pull request to merge your changes with the main development branch.

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -1,7 +1,17 @@
 ## What is the difference between push, pull, and fetch?
+Often `git push` and `git pull` are described as equivalent. This isn't entirely correct, since under the hood `git pull` does two things.
 
+### Push
 - `git push` - sent changes from a local branch to a remote repo
+
+`git push` takes our current branch, and checks to see whether or not there is a tracking branch for a remote repository connected to it. If so, our changes are taken from our branch and pushed to the remote branch. This is how code is shared with a remote repository, you can think of it as "make the remote branch resemble my local branch". This will fail if the remote branch has diverged from your local branch: if not all the commits in the remote branch are in your local branch. When this happens, your local branch needs to be synchronized with the remote branch with git pull or git fetch and git merge.
+
+### Fetch
 - `git fetch` - get changes from a remote repo into your tracking branch
+
+`git fetch` again takes our current branch, and checks to see if there is a tracking branch. If so, it looks for changes in the remote branch, and pulls them into the tracking branch. It does not change your local branch. To do that, you'll need to do `git merge origin/master` (for the "master" branch) to merge those changes into your branch - probably also called "master".
+
+### Pull
 - `git pull` - will get changes from a remote branch into your tracking branch and merge them into a local branch
 
-Often `git push` and `git pull` are described as equivalent. This isn't entirely correct, since under the hood `git pull` does two things. `git push` takes our current branch, and checks to see whether or not there is a tracking branch for a remote repository connected to it. If so, our changes are taken from our branch and pushed to the remote branch. This is how code is shared with a remote repository, you can think of it as "make the remote branch resemble my local branch". This will fail if the remote branch has diverged from your local branch: if not all the commits in the remote branch are in your local branch. When this happens, your local branch needs to be synchronized with the remote branch with git pull or git fetch and git merge.`git fetch` again takes our current branch, and checks to see if there is a tracking branch. If so, it looks for changes in the remote branch, and pulls them into the tracking branch. It does not change your local branch. To do that, you'll need to do `git merge origin/master` (for the "master" branch) to merge those changes into your branch - probably also called "master".`git pull` simply does a `git fetch` followed immediately by `git merge`. This is often what we desire to do, but some people prefer to use git fetch followed by git merge to make sure they understand the changes they are merging into their branch before the merge happens.
+`git pull` simply does a `git fetch` followed immediately by `git merge`. This is often what we desire to do, but some people prefer to use git fetch followed by git merge to make sure they understand the changes they are merging into their branch before the merge happens.

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -1,5 +1,5 @@
-## What is the difference between fetch, pull, and push?
-Git fetch, pull, and push are commands that help you understand and synchronize changes between a local and remote repository.
+## Review and share changes
+Git fetch, pull, and push are commands that help you understand and synchronize work between local and remote repositories.
 
 ### Fetch
 

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -3,14 +3,18 @@ Git fetch, pull, and push are commands that help you understand and synchronize 
 
 ### Fetch
 
-`git fetch` downloads all of the branches, tags, and changes from a remote repository into your local repository without changing your local files. This allows you to review changes before you add them into your work. 
+`git fetch` downloads all of the branches, tags, and changes from a remote repository into your local repository without changing your local files. This allows you to review changes before you add them into your work.
 
 When you're ready, use `git merge` to integrate changes into your local working branch.
 
 ### Pull
-- `git pull` - will get changes from a remote branch into your tracking branch and merge them into a local branch
 
-`git pull` simply does a `git fetch` followed immediately by `git merge`. This is often what we desire to do, but some people prefer to use git fetch followed by git merge to make sure they understand the changes they are merging into their branch before the merge happens.
+`git pull` combines two actions into the same operation:
+1. Download all of the branches, tags, and changes from a remote repository into your local repository.
+
+2. Integrate the changes from a remote tracking branch into your local tracking branch.
+
+This is equivalent to performing a `git fetch` and then a `git merge`. 
 
 ### Push
 - `git push` - sent changes from a local branch to a remote repo

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -2,9 +2,10 @@
 Git fetch, pull, and push are commands that help you understand and synchronize changes between a local and remote repository.
 
 ### Fetch
-- `git fetch` - get changes from a remote repo into your tracking branch
 
-`git fetch` again takes our current branch, and checks to see if there is a tracking branch. If so, it looks for changes in the remote branch, and pulls them into the tracking branch. It does not change your local branch. To do that, you'll need to do `git merge origin/master` (for the "master" branch) to merge those changes into your branch - probably also called "master".
+`git fetch` downloads all of the branches, tags, and changes from a remote repository into your local repository without changing your local files. This allows you to review changes before you add them into your work. 
+
+When you're ready, use `git merge` to integrate changes into your local working branch.
 
 ### Pull
 - `git pull` - will get changes from a remote branch into your tracking branch and merge them into a local branch

--- a/exercise-content.md
+++ b/exercise-content.md
@@ -1,5 +1,5 @@
 ## Review and share changes
-Git fetch, pull, and push are commands that help you understand and synchronize work between local and remote repositories.
+These git commands help you understand and synchronize work between local and remote repositories.
 
 ### Fetch
 


### PR DESCRIPTION
I have edited the description of git fetch, pull, and push so that it will be easier for users to read and understand. Note that I have made the following assumptions:
- Users are early to intermediate Git users. They are reviewing this help article because they’re not sure which command to use and when. 
- My colleagues and I have access to a larger documentation set about how to use Git. If I had access to the full documentation set, I would have added in-text links to key concepts like tracking branches and pull requests, so that users could easily find related help information. This approach supports new users while keeping this section concise and preventing the documentation from repeating the same information in multiple locations.